### PR TITLE
feat: parse `<expression-statement>`

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -85,7 +85,7 @@ export class DisallowedConstructError implements SourceError {
 export class FatalSyntaxError implements SourceError {
   public type = ErrorType.SYNTAX
   public severity = ErrorSeverity.ERROR
-  public constructor(public location: es.SourceLocation, public message: string) { }
+  public constructor(public location: es.SourceLocation, public message: string) {}
 
   public explain() {
     return this.message
@@ -99,7 +99,7 @@ export class FatalSyntaxError implements SourceError {
 export class MissingSemicolonError implements SourceError {
   public type = ErrorType.SYNTAX
   public severity = ErrorSeverity.ERROR
-  public constructor(public location: es.SourceLocation) { }
+  public constructor(public location: es.SourceLocation) {}
 
   public explain() {
     return 'Missing semicolon at the end of statement'
@@ -113,7 +113,7 @@ export class MissingSemicolonError implements SourceError {
 export class TrailingCommaError implements SourceError {
   public type: ErrorType.SYNTAX
   public severity: ErrorSeverity.WARNING
-  public constructor(public location: es.SourceLocation) { }
+  public constructor(public location: es.SourceLocation) {}
 
   public explain() {
     return 'Trailing comma'
@@ -347,7 +347,7 @@ class ExpressionGenerator implements CVisitor<es.Expression> {
       return expression
     } else {
       return {
-        type: "SequenceExpression",
+        type: 'SequenceExpression',
         expressions: [assignment]
       }
     }
@@ -362,7 +362,7 @@ class ExpressionGenerator implements CVisitor<es.Expression> {
         const lhsExpr = this.visitUnaryExpression(lhs) as es.Identifier
         const rhsExpr = this.visitAssignmentExpression(rhs)
         return {
-          type: "AssignmentExpression",
+          type: 'AssignmentExpression',
           operator: ctx.assignmentOperator()!.text as es.AssignmentOperator,
           left: lhsExpr,
           right: rhsExpr
@@ -370,7 +370,7 @@ class ExpressionGenerator implements CVisitor<es.Expression> {
       } else {
         throw new FatalSyntaxError(
           contextToLocation(lhs),
-          "LHS of assignment expression not allowed"
+          'LHS of assignment expression not allowed'
         )
       }
     } else {


### PR DESCRIPTION
Closes #6. Currently, LHS of assignment can only be identifier. To handle array access, and &, * expressions in the future.

```
<expression-statement> ::= {<expression>}? ;
```
```
<expression> ::= <assignment-expression>
               | <expression> , <assignment-expression>

<assignment-expression> ::= <conditional-expression>
                          | <unary-expression> <assignment-operator> <assignment-expression>

<assignment-operator> ::= =
                        | *=
                        | /=
                        | %=
                        | +=
                        | -=
<unary-expression> ::= <postfix-expression>
                     | ++ <unary-expression>
                     | -- <unary-expression>
                     | <unary-operator> <cast-expression>
```