### PR TITLE
feat: parse `<postfix-expression>` (array access and function call)

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -90,7 +90,7 @@ export class DisallowedConstructError implements SourceError {
 export class FatalSyntaxError implements SourceError {
   public type = ErrorType.SYNTAX
   public severity = ErrorSeverity.ERROR
-  public constructor(public location: es.SourceLocation, public message: string) { }
+  public constructor(public location: es.SourceLocation, public message: string) {}
 
   public explain() {
     return this.message
@@ -104,7 +104,7 @@ export class FatalSyntaxError implements SourceError {
 export class MissingSemicolonError implements SourceError {
   public type = ErrorType.SYNTAX
   public severity = ErrorSeverity.ERROR
-  public constructor(public location: es.SourceLocation) { }
+  public constructor(public location: es.SourceLocation) {}
 
   public explain() {
     return 'Missing semicolon at the end of statement'
@@ -118,7 +118,7 @@ export class MissingSemicolonError implements SourceError {
 export class TrailingCommaError implements SourceError {
   public type: ErrorType.SYNTAX
   public severity: ErrorSeverity.WARNING
-  public constructor(public location: es.SourceLocation) { }
+  public constructor(public location: es.SourceLocation) {}
 
   public explain() {
     return 'Trailing comma'
@@ -630,7 +630,7 @@ class ExpressionGenerator implements CVisitor<es.Expression> {
       return this.visitPrimaryExpression(ctx.primaryExpression()!)
     } else if (ctx.LeftBracket()) {
       return {
-        type: "MemberExpression",
+        type: 'MemberExpression',
         object: this.visitPostfixExpression(ctx.postfixExpression()!),
         property: this.visitExpression(ctx.expression()!),
         computed: false,
@@ -644,7 +644,7 @@ class ExpressionGenerator implements CVisitor<es.Expression> {
         head = head.argumentExpressionList()
       }
       return {
-        type: "CallExpression",
+        type: 'CallExpression',
         callee: this.visitPostfixExpression(ctx.postfixExpression()!),
         arguments: args,
         optional: false

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -90,7 +90,7 @@ export class DisallowedConstructError implements SourceError {
 export class FatalSyntaxError implements SourceError {
   public type = ErrorType.SYNTAX
   public severity = ErrorSeverity.ERROR
-  public constructor(public location: es.SourceLocation, public message: string) {}
+  public constructor(public location: es.SourceLocation, public message: string) { }
 
   public explain() {
     return this.message
@@ -104,7 +104,7 @@ export class FatalSyntaxError implements SourceError {
 export class MissingSemicolonError implements SourceError {
   public type = ErrorType.SYNTAX
   public severity = ErrorSeverity.ERROR
-  public constructor(public location: es.SourceLocation) {}
+  public constructor(public location: es.SourceLocation) { }
 
   public explain() {
     return 'Missing semicolon at the end of statement'
@@ -118,7 +118,7 @@ export class MissingSemicolonError implements SourceError {
 export class TrailingCommaError implements SourceError {
   public type: ErrorType.SYNTAX
   public severity: ErrorSeverity.WARNING
-  public constructor(public location: es.SourceLocation) {}
+  public constructor(public location: es.SourceLocation) { }
 
   public explain() {
     return 'Trailing comma'
@@ -626,9 +626,29 @@ class ExpressionGenerator implements CVisitor<es.Expression> {
   }
 
   visitPostfixExpression(ctx: PostfixExpressionContext): es.Expression {
-    // TODO: add support for other cases
     if (ctx.primaryExpression()) {
       return this.visitPrimaryExpression(ctx.primaryExpression()!)
+    } else if (ctx.LeftBracket()) {
+      return {
+        type: "MemberExpression",
+        object: this.visitPostfixExpression(ctx.postfixExpression()!),
+        property: this.visitExpression(ctx.expression()!),
+        computed: false,
+        optional: false
+      }
+    } else if (ctx.LeftParen()) {
+      const args: Array<es.Expression | es.SpreadElement> = []
+      let head = ctx.argumentExpressionList()
+      while (head) {
+        args.push(this.visitAssignmentExpression(head.assignmentExpression()))
+        head = head.argumentExpressionList()
+      }
+      return {
+        type: "CallExpression",
+        callee: this.visitPostfixExpression(ctx.postfixExpression()!),
+        arguments: args,
+        optional: false
+      }
     } else {
       const op = ctx.PlusPlus() ? '++' : '--'
       return {


### PR DESCRIPTION
Closes #40
for array access and function calls. 
```
<postfix-expression> ::= <primary-expression>
                       | <postfix-expression> [ <expression> ]
                       | <postfix-expression> ( {<assignment-expression>}* )
                       | <postfix-expression> ++
                       | <postfix-expression> --
```
```
<primary-expression> ::= <identifier>
                       | <constant>
                       | <string>
                       | ( <expression> )
```