### PR TITLE
feat: evaluate `<cast-expression>`

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -1,7 +1,7 @@
 // Variable determining chapter of Source is contained in this file.
 
 import { createGlobalEnvironment } from './environment'
-import { Context, Environment, Frame, Variant } from './types'
+import { Context, Environment, Variant } from './types'
 
 export class LazyBuiltIn {
   func: (...arg0: any) => any

--- a/src/evaluators/declarations.ts
+++ b/src/evaluators/declarations.ts
@@ -71,7 +71,7 @@ function* evaluateVariableDeclarator(node: VariableDeclarator, type: any, contex
   const kind = props[1]
   const init = node.init
   let value = init ? yield* actualValue(init as Expression, context) : undefined
-  value = evaluateCastExpression(value, kind)
+  value && (value = evaluateCastExpression(value, kind))
   const frame = getCurrentFrame(context)
   validateDeclarator(frame, name, kind, value, object.type)
   updateFrame(frame, name, kind, value)

--- a/src/evaluators/declarations.ts
+++ b/src/evaluators/declarations.ts
@@ -15,6 +15,7 @@ import { actualValue } from '../interpreter/interpreter'
 import { Kind } from '../types'
 import { actual } from '../utils/astMaps'
 import { validateDeclarator, validateFunction } from '../validator/validator'
+import { evaluateCastExpression } from './expressions'
 
 export function* evaluateVariableDeclaration(node: VariableDeclaration, context: any) {
   const kind = actual['kind'](node.kind)
@@ -68,7 +69,8 @@ function* evaluateVariableDeclarator(node: VariableDeclarator, type: any, contex
   const name = (props[0] as Identifier).name
   const kind = props[1]
   const init = node.init
-  const value = init ? yield* actualValue(init as Expression, context) : undefined
+  let value = init ? yield* actualValue(init as Expression, context) : undefined
+  value = evaluateCastExpression(value, kind)
   const frame = getCurrentFrame(context)
   validateDeclarator(frame, name, kind, value, object.type)
   updateFrame(frame, name, kind, value)

--- a/src/evaluators/expressions.ts
+++ b/src/evaluators/expressions.ts
@@ -137,9 +137,9 @@ export function evaluateCastExpression(value: any, type: any) {
   const valid = !kind.pointers || valueInt
   if (!valid) {
     const prim = kind.primitive.toString()
-    const ptr = kind.pointers ? (' ' + '*'.repeat(kind.pointers)) : ''
+    const ptr = kind.pointers ? ' ' + '*'.repeat(kind.pointers) : ''
     const type = prim + ptr
     throw new Error(`incompatible types when casting to type ${type}`)
   }
-  return (valueInt || kind.primitive === 'float') ? value : Math.trunc(value)
+  return valueInt || kind.primitive === 'float' ? value : Math.trunc(value)
 }

--- a/src/evaluators/expressions.ts
+++ b/src/evaluators/expressions.ts
@@ -140,7 +140,7 @@ export function evaluateCastExpression(value: number, kind: Kind) {
       ? parseFloat(value.toPrecision(6))
       : value
     : kind.primitive === 'float'
-      ? value
-      : Math.trunc(value)
+    ? value
+    : Math.trunc(value)
   return result
 }

--- a/src/evaluators/expressions.ts
+++ b/src/evaluators/expressions.ts
@@ -128,7 +128,7 @@ export function* evaluateUpdateExpression(
 }
 
 export function evaluateCastExpression(value: any, kind: Kind) {
-  // (float) [int *] is still valid in this implementation
+  // (float) [int *] is considered valid in this implementation
   const valueInt = Number.isInteger(value)
   const valid = !kind.pointers || valueInt
   if (!valid) {

--- a/src/evaluators/expressions.ts
+++ b/src/evaluators/expressions.ts
@@ -125,7 +125,7 @@ export function* evaluateUpdateExpression(
   }
 }
 
-export function evaluateCastExpression(value: any, kind: Kind) {
+export function evaluateCastExpression(value: number, kind: Kind) {
   // (float) [int *] is considered valid in this implementation
   const valueInt = Number.isInteger(value)
   const valid = !kind.pointers || valueInt
@@ -135,5 +135,12 @@ export function evaluateCastExpression(value: any, kind: Kind) {
     const type = prim + ptr
     throw new Error(`incompatible types when casting to type ${type}`)
   }
-  return valueInt || kind.primitive === 'float' ? value : Math.trunc(value)
+  const result = valueInt
+    ? kind.primitive === 'float'
+      ? value.toPrecision(24)
+      : value
+    : kind.primitive === 'float'
+    ? value
+    : Math.trunc(value)
+  return result
 }

--- a/src/evaluators/expressions.ts
+++ b/src/evaluators/expressions.ts
@@ -1,8 +1,6 @@
 import {
   ArrayExpression,
   AssignmentOperator,
-  BigIntLiteral,
-  Identifier,
   MemberExpression,
   Pattern,
   SequenceExpression,
@@ -11,7 +9,7 @@ import {
 
 import { getCurrentFrame, getGlobalFrame, lookupFrame, updateFrame } from '../environment'
 import { actualValue, evaluate } from '../interpreter/interpreter'
-import { Kind, toKind } from '../types'
+import { Kind } from '../types'
 
 export function* evaluateArrayExpression(node: ArrayExpression, context: any) {
   // TODO: handle array access
@@ -39,8 +37,8 @@ export function* evaluateCallExpression(
     const kind = global[name].kind
     const frame = getCurrentFrame(context)
     for (const param of params) {
-      const name = (param.object as Identifier).name
-      const kind = toKind(param.property as BigIntLiteral)
+      const name = param.name
+      const kind = param.kind
       const arg = evaluateCastExpression(args.shift(), kind)
       updateFrame(frame, name, kind, arg)
     }

--- a/src/evaluators/expressions.ts
+++ b/src/evaluators/expressions.ts
@@ -11,6 +11,7 @@ import {
 
 import { getCurrentFrame, getGlobalFrame, lookupFrame, updateFrame } from '../environment'
 import { actualValue, evaluate } from '../interpreter/interpreter'
+import { Kind } from '../types'
 
 export function* evaluateArrayExpression(node: ArrayExpression, context: any) {
   // TODO: handle array access
@@ -124,4 +125,21 @@ export function* evaluateUpdateExpression(
     updateFrame(frame, name, id.kind, after)
     return prefix ? after : before
   }
+}
+
+export function evaluateCastExpression(value: any, type: any) {
+  const kind = {
+    primitive: type.bigint,
+    pointers: type.value as unknown as number
+  } as Kind
+  // (float) [int *] is still valid in this implementation
+  const valueInt = Number.isInteger(value)
+  const valid = !kind.pointers || valueInt
+  if (!valid) {
+    const prim = kind.primitive.toString()
+    const ptr = kind.pointers ? (' ' + '*'.repeat(kind.pointers)) : ''
+    const type = prim + ptr
+    throw new Error(`incompatible types when casting to type ${type}`)
+  }
+  return (valueInt || kind.primitive === 'float') ? value : Math.trunc(value)
 }

--- a/src/evaluators/expressions.ts
+++ b/src/evaluators/expressions.ts
@@ -44,7 +44,7 @@ export function* evaluateCallExpression(
     }
 
     let result = yield* evaluate(body, context)
-    result = evaluateCastExpression(result, kind)
+    name !== 'main' && (result = evaluateCastExpression(result, kind))
     if (context.prelude === 'return') {
       context.prelude = null
     }
@@ -137,10 +137,10 @@ export function evaluateCastExpression(value: number, kind: Kind) {
   }
   const result = valueInt
     ? kind.primitive === 'float'
-      ? value.toPrecision(24)
+      ? parseFloat(value.toPrecision(6))
       : value
     : kind.primitive === 'float'
-    ? value
-    : Math.trunc(value)
+      ? value
+      : Math.trunc(value)
   return result
 }

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -41,7 +41,7 @@ import {
   evaluateReturnStatement,
   evaluateWhileStatement
 } from '../evaluators/statements'
-import { Context, Environment, Value } from '../types'
+import { Context, Environment, Kind, toKind, Value } from '../types'
 
 class Thunk {
   public value: Value
@@ -179,7 +179,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
 
   MemberExpression: function* (node: es.MemberExpression, context: Context) {
     const value = yield* actualValue(node.object, context)
-    const kind = node.property as es.BigIntLiteral
+    const kind = toKind(node.property as es.BigIntLiteral)
     return evaluateCastExpression(value, kind)
   },
 

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -135,7 +135,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     const value = yield* actualValue(callee, context)
     const args = []
     for (const arg of node.arguments) {
-      args.unshift(yield* actualValue(arg, context))
+      args.push(yield* actualValue(arg, context))
     }
     
     context.prelude = name

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -22,6 +22,7 @@ import {
   evaluateArrayExpression,
   evaluateAssignmentExpression,
   evaluateCallExpression,
+  evaluateCastExpression,
   evaluateConditionalExpression,
   evaluateFunctionExpression,
   evaluateSequenceExpression,
@@ -174,6 +175,12 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   LogicalExpression: function* (node: es.LogicalExpression, context: Context) {
     const left = yield* actualValue(node.left, context)
     return yield* evaluateLogicalExpression(node.operator, left, node.right, context)
+  },
+
+  MemberExpression: function* (node: es.MemberExpression, context: Context) {
+    const value = yield* actualValue(node.object, context)
+    const kind = node.property as es.BigIntLiteral
+    return evaluateCastExpression(value, kind)
   },
 
   VariableDeclaration: function* (node: es.VariableDeclaration, context: Context) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -388,3 +388,8 @@ export interface Kind {
   pointers: number
   dimensions?: [number]
 }
+
+export const toKind = (kind: es.BigIntLiteral) => ({
+  primitive: kind.bigint,
+  pointers: kind.value as unknown as number
+} as Kind)

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,7 +389,8 @@ export interface Kind {
   dimensions?: [number]
 }
 
-export const toKind = (kind: es.BigIntLiteral) => ({
-  primitive: kind.bigint,
-  pointers: kind.value as unknown as number
-} as Kind)
+export const toKind = (kind: es.BigIntLiteral) =>
+  ({
+    primitive: kind.bigint,
+    pointers: kind.value as unknown as number
+  } as Kind)


### PR DESCRIPTION
close #34 

- type cast: **`(float) [int *]` is considered valid in the current implementation**
- type conversion: call expressions, assignment expressions, variable declarations