### PR TITLE
fix: fix bug in `allocateMemory` 

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -91,9 +91,9 @@ export class Memory {
       this.allocateMemory(arr[count], elementKind, isHeap)
     }
     if (isHeap) {
-      this.heapPointer += numElements
+      this.heapPointer = address + numElements
     } else {
-      this.stackPointer -= numElements
+      this.stackPointer = address - numElements
     }
     this.checkHeapSmallerThanStack()
     return address


### PR DESCRIPTION
fix bug that causes extra memory to be allocated for array